### PR TITLE
Support COMAL 80 .crt

### DIFF
--- a/CORE/vhdl/cartridge.vhd
+++ b/CORE/vhdl/cartridge.vhd
@@ -284,6 +284,22 @@ begin
                   bank_hi_o <= (others => '0');
                end if;
 
+            when 21 =>
+               -- COMAL 80 - (game=0, exrom=0 = 4 16k banks)
+               if ioe_i = '1' and wr_en_i = '1' then
+                  bank_lo_o <= "00000" & wr_data_i(1 downto 0);
+                  bank_hi_o <= "00000" & wr_data_i(1 downto 0);
+                  exrom_o   <= wr_data_i(6);
+                  game_o    <= wr_data_i(6);
+               end if;
+               if cart_loading_i = '1' then
+                  game_o       <= '0';
+                  exrom_o      <= '0';
+                  cart_disable <= '0';
+                  bank_lo_o    <= (others => '0');
+                  bank_hi_o    <= (others => '0');
+               end if;
+
             when 32 =>
                -- EASYFLASH - 1mb 128x8k/64x16k, XBank format(33) looks the same
                -- upd: original Easyflash(32) boots in ultimax mode.


### PR DESCRIPTION
As discussed in PR #4, this commit is now based on the V5.2A1 branch.

This small PR adds support for the COMAL 80 .crt. The `GAME` and `EXROM` control is very different to the VICE implementation (which also works fine, when implemented in cartridge.vhd), but the PR's implementation is simpler *and* consistent with [the schematics](https://github.com/acarmony1/comal80/blob/master/C64/comal80_sch.pdf), which I therefore consider the correct one.